### PR TITLE
Cycle start correction for a cycle across two months

### DIFF
--- a/app/src/main/java/com/log28/CalendarView.kt
+++ b/app/src/main/java/com/log28/CalendarView.kt
@@ -104,7 +104,11 @@ class CalendarView : Fragment() {
 
     // TODO there might be an off by 1 error somewhere in here
     private fun predictFuturePeriods(periodDates: MutableList<Long>): MutableList<Long> {
-        var cycleStart = periodDates.filter { item -> item -1 !in periodDates }.max()?.toCalendar()
+        var cycleStart = periodDates.filter { item ->
+            val previousDay = item.toCalendar()
+            previousDay.add(Calendar.DAY_OF_MONTH, -1)
+            previousDay.formatDate() !in periodDates
+        }.max()?.toCalendar()
                 ?: return periodDates
 
         //the earliest day we can predict the next period for is tomorrow


### PR DESCRIPTION
Use of `Calendar`'s method to subtract a day instead of subtract operation on a `Long` variable, causing an erroneous cycle start for cycles across two months.
