### PR TITLE
Fixes for issues #5 and #19

### DIFF
--- a/app/src/main/java/com/log28/UpdatableScrollCalendar.java
+++ b/app/src/main/java/com/log28/UpdatableScrollCalendar.java
@@ -16,6 +16,7 @@ package com.log28;
         import android.util.AttributeSet;
         import android.widget.LinearLayout;
 
+        import pl.rafman.scrollcalendar.adapter.FixScrollCalendarAdapter;
         import pl.rafman.scrollcalendar.adapter.LegendItem;
         import pl.rafman.scrollcalendar.adapter.ResProvider;
         import pl.rafman.scrollcalendar.adapter.ScrollCalendarAdapter;
@@ -138,7 +139,7 @@ public class UpdatableScrollCalendar extends LinearLayoutCompat implements ResPr
         refreshLegend();
         // RecyclerView
         RecyclerView recyclerView = findViewById(R.id.recyclerView);
-        recyclerView.setLayoutManager(new LinearLayoutManager(getContext(), VERTICAL, false));
+        recyclerView.setLayoutManager(new LinearLayoutManager(getContext(), RecyclerView.VERTICAL, false));
         recyclerView.setAdapter(getAdapter());
     }
 
@@ -151,7 +152,7 @@ public class UpdatableScrollCalendar extends LinearLayoutCompat implements ResPr
     @NonNull
     public ScrollCalendarAdapter getAdapter() {
         if (adapter == null) {
-            adapter = new ScrollCalendarAdapter(this);
+            adapter = new FixScrollCalendarAdapter(this);
         }
         return adapter;
     }
@@ -252,6 +253,5 @@ public class UpdatableScrollCalendar extends LinearLayoutCompat implements ResPr
             return null;
         }
     }
-
 
 }

--- a/app/src/main/java/com/log28/intro/LastPeriodFragment.kt
+++ b/app/src/main/java/com/log28/intro/LastPeriodFragment.kt
@@ -49,14 +49,16 @@ class LastPeriodFragment: Fragment() {
         val today = Calendar.getInstance()
         last_period_calendar.setDateWatcher {
             year, month, day ->
-            if (year == today.get(Calendar.YEAR) &&
-                    month == today.get(Calendar.MONTH) && day == today.get(Calendar.DAY_OF_MONTH)) {
-                CalendarDay.TODAY
-            } else if (year == dateSelected?.get(Calendar.YEAR) &&
+            if (year == dateSelected?.get(Calendar.YEAR) &&
                     month == dateSelected?.get(Calendar.MONTH) && day == dateSelected?.get(Calendar.DAY_OF_MONTH)) {
                 Log.d("LASTPERIOD", "highlighting $year, $month, $day. dateSelected is ${dateSelected?.formatDate()}")
                 CalendarDay.SELECTED
-            } else CalendarDay.DEFAULT
+            } else if (year == today.get(Calendar.YEAR) &&
+                    month == today.get(Calendar.MONTH) && day == today.get(Calendar.DAY_OF_MONTH)) {
+                CalendarDay.TODAY
+            } else {
+                CalendarDay.DEFAULT
+            }
         }
 
 
@@ -68,7 +70,7 @@ class LastPeriodFragment: Fragment() {
             firstDay.set(Calendar.DAY_OF_MONTH, day)
             Log.d("LASTPERIOD", "click on day ${firstDay.formatDate()}")
 
-            if (firstDay.before(Calendar.getInstance())) {
+            if (!firstDay.after(Calendar.getInstance())) {
                 dateSelected = firstDay
                 (this.activity as AppIntroActivity).setupComplete = true
                 realm.setFirstPeriod(firstDay.clone() as Calendar, this.context)

--- a/app/src/main/java/pl/rafman/scrollcalendar/adapter/FixMonthViewHolder.java
+++ b/app/src/main/java/pl/rafman/scrollcalendar/adapter/FixMonthViewHolder.java
@@ -1,0 +1,90 @@
+package pl.rafman.scrollcalendar.adapter;
+
+import android.graphics.Typeface;
+import android.util.TypedValue;
+import android.view.View;
+import android.widget.LinearLayout;
+import android.widget.TextView;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
+import com.log28.R;
+
+import java.util.Calendar;
+
+import pl.rafman.scrollcalendar.contract.ClickCallback;
+import pl.rafman.scrollcalendar.data.CalendarDay;
+import pl.rafman.scrollcalendar.data.CalendarMonth;
+
+public class FixMonthViewHolder extends MonthViewHolder {
+
+    @Nullable
+    private final TextView title; // Duplicate the superclass' value because it's private :(
+
+    private final WeekHolder[] weeks = new WeekHolder[6]; // Duplicate the superclass' value because it's private :(
+
+    public FixMonthViewHolder(@NonNull View rootView, @NonNull ClickCallback calendarCallback, @NonNull ResProvider resProvider) {
+        super(rootView);
+
+        LinearLayout monthContainer = rootView.findViewById(R.id.monthContainer);
+
+        title = rootView.findViewById(R.id.title);
+        Typeface typeface = resProvider.getCustomFont();
+        if (typeface != null) {
+            title.setTypeface(typeface);
+        }
+        title.setTextSize(TypedValue.COMPLEX_UNIT_PX, resProvider.fontSize());
+
+        for (int i = 0; i < weeks.length; i++) {
+            weeks[i] = new WeekHolder(calendarCallback, resProvider);
+            monthContainer.addView(weeks[i].layout(monthContainer));
+        }
+    }
+
+    void bind(CalendarMonth month) {
+        if (title != null) {
+            title.setText(month.getReadableMonthName());
+        }
+
+        Calendar calendar = Calendar.getInstance();
+        calendar.setFirstDayOfWeek(Calendar.SUNDAY);
+        calendar.set(Calendar.YEAR, month.getYear());
+        calendar.set(Calendar.MONTH, month.getMonth());
+        calendar.set(Calendar.HOUR_OF_DAY, 0);
+        calendar.set(Calendar.MINUTE, 0);
+        calendar.set(Calendar.SECOND, 0);
+        calendar.set(Calendar.MILLISECOND, 0);
+
+        // Set calendar to the first day of the month, then go back to the start of the week...
+        calendar.set(Calendar.DAY_OF_MONTH, month.getDays()[0].getDay());
+        while(calendar.get(Calendar.DAY_OF_WEEK)!=calendar.getFirstDayOfWeek()) {
+            calendar.add(Calendar.DAY_OF_MONTH, -1);
+        }
+
+        CalendarDay monthDays[] = month.getDays();
+
+        int weekIndex = 0;
+
+        // Create and display weeks, so long as we have days in month.
+        for(int dayIndex = 0; dayIndex <monthDays.length; weekIndex++) {
+            CalendarDay weekDays[] = new CalendarDay[7];
+
+            for(int i=0;i<7;i++) {
+                if (calendar.get(Calendar.MONTH)==month.getMonth() && dayIndex <monthDays.length && calendar.get(Calendar.DAY_OF_MONTH)==monthDays[dayIndex].getDay()) {
+                    weekDays[i] = monthDays[dayIndex];
+                    dayIndex++;
+                }
+                calendar.add(Calendar.DAY_OF_MONTH, 1);
+            }
+
+            weeks[weekIndex].display(weekIndex+1, month, weekDays);
+        }
+
+        // Add empty weeks if necessary.
+        for(;weekIndex<weeks.length;weekIndex++) {
+            weeks[weekIndex].display(weekIndex+1, month, new CalendarDay[0]);
+        }
+    }
+
+}

--- a/app/src/main/java/pl/rafman/scrollcalendar/adapter/FixScrollCalendarAdapter.java
+++ b/app/src/main/java/pl/rafman/scrollcalendar/adapter/FixScrollCalendarAdapter.java
@@ -1,0 +1,27 @@
+package pl.rafman.scrollcalendar.adapter;
+
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.ViewGroup;
+
+import androidx.annotation.NonNull;
+
+import com.log28.R;
+
+public final class FixScrollCalendarAdapter extends ScrollCalendarAdapter {
+
+    private final @NonNull ResProvider resProvider; // Duplicate the superclass' value because it's private :(
+
+    public FixScrollCalendarAdapter(@NonNull ResProvider resProvider) {
+        super(resProvider);
+        this.resProvider = resProvider;
+    }
+
+    @Override
+    public MonthViewHolder onCreateViewHolder(ViewGroup parent, int viewType) {
+        @NonNull View rootView = LayoutInflater.from(parent.getContext()).inflate(R.layout.scrollcalendar_month, parent, false);
+
+        return new FixMonthViewHolder(rootView, this, this.resProvider);
+    }
+
+}


### PR DESCRIPTION
There is an issue with the calendars sometimes not showing the first days of the month (issue #5).

This is due to scrollcalendar relying on calendar.get(Calendar.WEEK_OF_MONTH): the first week of the month does not necessarily contains the first day of the month (see java.util.Calendar javadoc, "First Week").

The fix involves extending ScrollCalendarAdapter and MonthViewHolder to process days correctly in the latter's bind method. This has to be done in the same package as the original code because MonthViewHolder has package visibility. Not nice, but it works.